### PR TITLE
Add login functionality

### DIFF
--- a/Integrade/README.md.txt
+++ b/Integrade/README.md.txt
@@ -1,0 +1,13 @@
+# Integrade
+
+This project embeds interactive widgets in a Learning Management System. The new `login.html` page allows users to sign in before accessing their activities.
+
+## Setup
+
+1. Configure database credentials in `includes/config.php`.
+2. Create a `users` table with columns `id`, `username`, and `password_hash`.
+3. Serve the project using a PHP-capable web server.
+
+## Usage
+
+Visit `login.html` to sign in. After successful login you will be redirected to `index.html` where activities can be launched.

--- a/Integrade/includes/config.php
+++ b/Integrade/includes/config.php
@@ -1,0 +1,6 @@
+<?php
+// Database configuration - replace with real credentials
+define('DB_HOST', 'localhost');
+define('DB_USER', 'username');
+define('DB_PASS', 'password');
+define('DB_NAME', 'integrade');

--- a/Integrade/includes/db.php
+++ b/Integrade/includes/db.php
@@ -1,0 +1,18 @@
+<?php
+require_once 'config.php';
+
+function get_db_connection() {
+    static $conn;
+    if (!$conn) {
+        $dsn = 'mysql:host='.DB_HOST.';dbname='.DB_NAME.';charset=utf8mb4';
+        try {
+            $conn = new PDO($dsn, DB_USER, DB_PASS);
+            $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        } catch (PDOException $e) {
+            http_response_code(500);
+            echo json_encode(['success' => false, 'error' => 'DB connection failed']);
+            exit;
+        }
+    }
+    return $conn;
+}

--- a/Integrade/includes/login.php
+++ b/Integrade/includes/login.php
@@ -1,0 +1,24 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+
+$username = $_POST['username'] ?? '';
+$password = $_POST['password'] ?? '';
+
+if (!$username || !$password) {
+    echo json_encode(['success' => false, 'error' => 'Missing credentials']);
+    exit;
+}
+
+$conn = get_db_connection();
+$stmt = $conn->prepare('SELECT id, password_hash FROM users WHERE username = ?');
+$stmt->execute([$username]);
+$user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if ($user && password_verify($password, $user['password_hash'])) {
+    session_start();
+    $_SESSION['user_id'] = $user['id'];
+    echo json_encode(['success' => true]);
+} else {
+    echo json_encode(['success' => false, 'error' => 'Invalid credentials']);
+}

--- a/Integrade/login.html
+++ b/Integrade/login.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Login | Integrade</title>
+  <link rel="stylesheet" href="main.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@100..900&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header>
+    <img src="images/integrade.png" alt="Integrade Logo" class="logo" />
+  </header>
+
+  <main>
+    <form id="login-form" class="launch-panel">
+      <div class="form-header accent-bg">Login</div>
+      <label for="username">Username</label>
+      <input type="text" id="username" name="username" required />
+
+      <label for="password">Password</label>
+      <input type="password" id="password" name="password" required />
+
+      <button type="submit">Login</button>
+    </form>
+  </main>
+
+  <footer>
+    <p>Built by Noah Schaffer</p>
+  </footer>
+
+  <script src="scripts/login.js"></script>
+</body>
+</html>

--- a/Integrade/scripts/login.js
+++ b/Integrade/scripts/login.js
@@ -1,0 +1,22 @@
+const loginForm = document.getElementById('login-form');
+if (loginForm) {
+  loginForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const formData = new FormData(loginForm);
+    try {
+      const res = await fetch('includes/login.php', {
+        method: 'POST',
+        body: formData
+      });
+      const data = await res.json();
+      if (data.success) {
+        window.location.href = 'index.html';
+      } else {
+        alert('Login failed');
+      }
+    } catch (err) {
+      console.error('Login error', err);
+      alert('Login request failed');
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add `login.html` as the entry page
- create `scripts/login.js` for submitting credentials
- add PHP backend files (`login.php`, `db.php`, `config.php`)
- update README with setup instructions

## Testing
- `php -l` (fails: php not installed)

------
https://chatgpt.com/codex/tasks/task_e_683fecf3cbe883269f7929c573ea5d84