### PR TITLE
Add activity persistence

### DIFF
--- a/Integrade/README.md.txt
+++ b/Integrade/README.md.txt
@@ -6,7 +6,8 @@ This project embeds interactive widgets in a Learning Management System. The `lo
 
 1. Configure database credentials in `includes/config.php`.
 2. Create a `users` table with columns `id`, `username`, and `password_hash`.
-3. Serve the project using a PHP-capable web server.
+3. Create an `activities` table with columns `id`, `user_id`, `name`, and `created_at`.
+4. Serve the project using a PHP-capable web server.
 
 ## Usage
 

--- a/Integrade/includes/activities.php
+++ b/Integrade/includes/activities.php
@@ -1,0 +1,36 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+session_start();
+
+$user_id = $_SESSION['user_id'] ?? null;
+if (!$user_id) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'error' => 'Not authenticated']);
+    exit;
+}
+
+$conn = get_db_connection();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['name'] ?? '');
+    if ($name === '') {
+        echo json_encode(['success' => false, 'error' => 'Missing name']);
+        exit;
+    }
+    $stmt = $conn->prepare('INSERT INTO activities (user_id, name, created_at) VALUES (?, ?, NOW())');
+    try {
+        $stmt->execute([$user_id, $name]);
+        $id = $conn->lastInsertId();
+        echo json_encode(['success' => true, 'id' => $id]);
+    } catch (PDOException $e) {
+        http_response_code(500);
+        echo json_encode(['success' => false, 'error' => 'DB insert failed']);
+    }
+    exit;
+}
+
+$stmt = $conn->prepare('SELECT id, name, created_at FROM activities WHERE user_id = ? ORDER BY created_at DESC');
+$stmt->execute([$user_id]);
+$activities = $stmt->fetchAll(PDO::FETCH_ASSOC);
+echo json_encode(['success' => true, 'activities' => $activities]);

--- a/Integrade/index.html
+++ b/Integrade/index.html
@@ -28,10 +28,14 @@
 
     <form id="return-form" class="launch-panel">
         <div class="form-header secondary-bg">Access a Saved Activity</div>
-      <label for="returnRoomName">Activity Name:</label>
-      <input type="text" id="returnRoomName" name="returnRoomName" required />
-      <button type="submit">Access Activity</button>
-    </form>
+        <div id="activities-loading">Loading...</div>
+        <div id="activity-select-container" style="display:none;">
+          <label for="activitySelect">Your Activities:</label>
+          <select id="activitySelect" name="activitySelect"></select>
+        </div>
+        <p id="noActivitiesMessage" class="center-text" style="display:none;">No saved activities yet</p>
+        <button type="submit">Access Activity</button>
+      </form>
   </div>
 </main>
 

--- a/Integrade/scripts/index.js
+++ b/Integrade/scripts/index.js
@@ -1,13 +1,30 @@
 // Handle new activity creation
 const roomForm = document.getElementById("room-form");
 if (roomForm) {
-  roomForm.addEventListener("submit", function (e) {
+  roomForm.addEventListener("submit", async (e) => {
     e.preventDefault();
     const roomName = document.getElementById("roomName").value.trim();
 
     if (!roomName) {
       alert("Please enter an activity name.");
       return;
+    }
+
+    const formData = new FormData();
+    formData.append("name", roomName);
+
+    try {
+      const res = await fetch("includes/activities.php", {
+        method: "POST",
+        body: formData,
+      });
+      const data = await res.json();
+      if (!data.success) {
+        alert("Failed to save activity");
+        return;
+      }
+    } catch (err) {
+      console.error("Activity creation failed", err);
     }
 
     localStorage.setItem("integradeRoom", roomName);
@@ -17,17 +34,46 @@ if (roomForm) {
 
 // Handle returning to existing activity
 const returnForm = document.getElementById("return-form");
+const activitySelect = document.getElementById("activitySelect");
+const activityLoading = document.getElementById("activities-loading");
+const activityContainer = document.getElementById("activity-select-container");
+const noActivitiesMessage = document.getElementById("noActivitiesMessage");
+
+async function loadActivities() {
+  if (!activityLoading) return;
+  try {
+    const res = await fetch("includes/activities.php");
+    const data = await res.json();
+    activityLoading.style.display = "none";
+    if (data.success && data.activities && data.activities.length > 0) {
+      data.activities.forEach((act) => {
+        const opt = document.createElement("option");
+        opt.value = act.name;
+        opt.textContent = act.name;
+        activitySelect.appendChild(opt);
+      });
+      activityContainer.style.display = "block";
+    } else {
+      noActivitiesMessage.style.display = "block";
+    }
+  } catch (err) {
+    activityLoading.textContent = "Failed to load activities";
+    console.error("Load activities error", err);
+  }
+}
+
 if (returnForm) {
   returnForm.addEventListener("submit", function (e) {
     e.preventDefault();
-    const roomName = document.getElementById("returnRoomName").value.trim();
+    const roomName = activitySelect.value;
 
     if (!roomName) {
-      alert("Please enter the name of your previous activity.");
+      alert("Please select an activity.");
       return;
     }
 
     localStorage.setItem("integradeRoom", roomName);
     window.location.href = "widgets/widgets.html";
   });
+  loadActivities();
 }


### PR DESCRIPTION
## Summary
- list a user's saved activities on the home page
- create a new endpoint to save/fetch activities
- persist activities when starting a new one
- update setup instructions for new table

## Testing
- `npm test` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683ff6787e8c8326a6b1fc5dcbab4f60