### PR TITLE
Fix jamboard layout and save posts

### DIFF
--- a/Integrade/includes/jamboard_posts.php
+++ b/Integrade/includes/jamboard_posts.php
@@ -1,0 +1,42 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+
+$conn = get_db_connection();
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+if ($method === 'GET') {
+    $room = $_GET['room'] ?? '';
+    $stmt = $conn->prepare('SELECT id, room, username, avatar, title, content, attachment, filename, created_at FROM jamboard_posts WHERE room = ? ORDER BY created_at DESC');
+    $stmt->execute([$room]);
+    $posts = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode(['success' => true, 'posts' => $posts]);
+    exit;
+}
+
+if ($method === 'POST') {
+    $data = json_decode(file_get_contents('php://input'), true);
+    if (!$data) { echo json_encode(['success' => false, 'error' => 'Invalid data']); exit; }
+    $stmt = $conn->prepare('INSERT INTO jamboard_posts (room, username, avatar, title, content, attachment, filename, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, NOW())');
+    try {
+        $stmt->execute([
+            $data['room'] ?? '',
+            $data['username'] ?? 'Anonymous',
+            $data['avatar'] ?? '',
+            $data['title'] ?? '',
+            $data['content'] ?? '',
+            $data['attachment'] ?? '',
+            $data['filename'] ?? ''
+        ]);
+        $id = $conn->lastInsertId();
+        echo json_encode(['success' => true, 'id' => $id]);
+    } catch (PDOException $e) {
+        http_response_code(500);
+        echo json_encode(['success' => false, 'error' => 'DB insert failed']);
+    }
+    exit;
+}
+
+http_response_code(405);
+echo json_encode(['success' => false, 'error' => 'Method not allowed']);

--- a/Integrade/widgets/jamboard/jamboard.css
+++ b/Integrade/widgets/jamboard/jamboard.css
@@ -62,6 +62,7 @@ body {
   align-items: center;
   position: relative;
   margin-bottom: 1rem;
+  height: 80px; /* keep space for logo */
   /* padding: 0 10px; No specific padding, rely on body/app-container */
 }
 
@@ -86,7 +87,7 @@ body {
     border: 1px solid var(--card-border-color);
     border-radius: 8px;
     padding: 1rem; /* Consistent padding */
-    margin: 0 auto 2rem auto; /* Centered and margin like widgets */
+    margin: 1rem auto 2rem auto; /* Centered and margin like widgets */
     max-width: 600px; /* Consistent with other central elements */
     text-align: center;
     color: var(--card-text-color);

--- a/Integrade/widgets/jamboard/jamboard.html
+++ b/Integrade/widgets/jamboard/jamboard.html
@@ -35,13 +35,9 @@
                 <input type="text" id="post-subject-input" placeholder="Subject">
                 <div class="modal-body">
                     <div class="toolbar-icons">
-                        <label for="modal-file-upload" class="toolbar-icon" aria-label="Attach file">📄
+                        <label for="modal-file-upload" class="toolbar-icon" aria-label="Attach file">📎
                             <input type="file" id="modal-file-upload" accept=".png,.jpg,.jpeg,.pdf,.gif" style="display: none;">
                         </label>
-                        <button class="toolbar-icon" aria-label="Insert link">🔗</button>
-                        <button class="toolbar-icon" aria-label="Add image">📷</button>
-                        <button class="toolbar-icon" aria-label="GIF">🎨</button>
-                        <!-- <button class="toolbar-icon more-options" aria-label="More options">+13</button> -->
                         <span id="modal-file-name" class="modal-file-name-display"></span>
                     </div>
                     <textarea id="post-text-input" placeholder="Write something incredible..."></textarea>


### PR DESCRIPTION
## Summary
- add database endpoints for jamboard posts
- tweak jamboard header spacing and prompt position
- keep only one file attachment emoji
- persist jamboard posts to backend and display stored posts

## Testing
- `php -l includes/jamboard_posts.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffcd3e3988326a4945cb265298a72