### PR TITLE
Fix jamboard modal controls

### DIFF
--- a/Integrade/widgets/jamboard/jamboard.css
+++ b/Integrade/widgets/jamboard/jamboard.css
@@ -374,8 +374,6 @@ body {
     text-align: center; cursor: pointer; margin-right: 8px;
 }
 .modal-window-btn.close-btn { background: #ff5f57; }
-.modal-window-btn:nth-child(2) { background: #febb2e; }
-.modal-window-btn:nth-child(3) { background: #28c840; }
 
 .modal-content input[type="text"]#post-subject-input { /* More specific selector */
     background-color: transparent;

--- a/Integrade/widgets/jamboard/jamboard.html
+++ b/Integrade/widgets/jamboard/jamboard.html
@@ -29,8 +29,6 @@
             <div class="modal-content">
                 <div class="modal-window-controls">
                     <button class="modal-window-btn close-btn" id="modal-close-main">×</button>
-                    <button class="modal-window-btn" aria-label="Expand">↖</button>
-                    <button class="modal-window-btn" aria-label="Minimize">−</button>
                 </div>
                 <input type="text" id="post-subject-input" placeholder="Subject">
                 <div class="modal-body">
@@ -43,7 +41,7 @@
                     <textarea id="post-text-input" placeholder="Write something incredible..."></textarea>
                 </div>
                 <div class="modal-actions">
-                    <button id="publish-post-button" class="publish-btn" disabled>Publish</button>
+                    <button id="publish-post-button" class="publish-btn" disabled>Post</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- clean up modal window control buttons so only the close button remains
- rename Publish button text to **Post**

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fff76a7348326ac624df6ad77d5a9