### PR TITLE
Add dynamic poll questions and slider UI

### DIFF
--- a/Integrade/README.md.txt
+++ b/Integrade/README.md.txt
@@ -7,7 +7,8 @@ This project embeds interactive widgets in a Learning Management System. The `lo
 1. Configure database credentials in `includes/config.php`.
 2. Create a `users` table with columns `id`, `username`, and `password_hash`.
 3. Create an `activities` table with columns `id`, `user_id`, `name`, and `created_at`.
-4. Serve the project using a PHP-capable web server.
+4. Create a `poll_results` table with columns `id`, `room`, `question_idx`, `option_idx`, and `created_at` for storing poll submissions.
+5. Serve the project using a PHP-capable web server.
 
 ## Usage
 

--- a/Integrade/includes/poll_results.php
+++ b/Integrade/includes/poll_results.php
@@ -1,0 +1,51 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+
+$conn = get_db_connection();
+$method = $_SERVER['REQUEST_METHOD'];
+
+if ($method === 'POST') {
+    $data = json_decode(file_get_contents('php://input'), true);
+    if (!$data || !isset($data['room']) || !isset($data['answers']) || !is_array($data['answers'])) {
+        echo json_encode(['success' => false, 'error' => 'Invalid data']);
+        exit;
+    }
+    $room = $data['room'];
+    $answers = $data['answers'];
+    $stmt = $conn->prepare('INSERT INTO poll_results (room, question_idx, option_idx, created_at) VALUES (?, ?, ?, NOW())');
+    try {
+        foreach ($answers as $idx => $choice) {
+            $stmt->execute([$room, $idx, $choice]);
+        }
+        echo json_encode(['success' => true]);
+    } catch (PDOException $e) {
+        http_response_code(500);
+        echo json_encode(['success' => false, 'error' => 'DB insert failed']);
+    }
+    exit;
+}
+
+if ($method === 'GET') {
+    $room = $_GET['room'] ?? '';
+    if ($room === '') {
+        echo json_encode(['success' => false, 'error' => 'Missing room']);
+        exit;
+    }
+    $stmt = $conn->prepare('SELECT question_idx, option_idx, COUNT(*) as cnt FROM poll_results WHERE room = ? GROUP BY question_idx, option_idx');
+    $stmt->execute([$room]);
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $results = [];
+    foreach ($rows as $row) {
+        $q = (int)$row['question_idx'];
+        $o = (int)$row['option_idx'];
+        if (!isset($results[$q])) $results[$q] = [];
+        $results[$q][$o] = (int)$row['cnt'];
+    }
+    echo json_encode(['success' => true, 'results' => $results]);
+    exit;
+}
+
+http_response_code(405);
+echo json_encode(['success' => false, 'error' => 'Method not allowed']);

--- a/Integrade/widgets/poll/poll.css
+++ b/Integrade/widgets/poll/poll.css
@@ -1,0 +1,83 @@
+:root {
+  --primary: #04010c;
+  --cream: #fefaeb;
+  --accent: #00d0a9;
+  --secondary: #8604e7;
+  --light_gray: #373737;
+  --font: 'League Spartan', sans-serif;
+}
+
+body {
+  font-family: var(--font);
+  background-color: var(--primary);
+  color: var(--cream);
+  line-height: 1.6;
+  padding: 2rem;
+}
+
+.app-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.header-top-row {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 80px;
+}
+
+.header-logo {
+  height: 80px;
+  object-fit: contain;
+}
+
+.poll-container {
+  max-width: 600px;
+  margin: 0 auto;
+  background-color: var(--light_gray);
+  padding: 1rem;
+  border-radius: 8px;
+}
+
+.poll-question-block {
+  margin-bottom: 2rem;
+}
+
+.poll-question {
+  color: var(--accent);
+  margin-bottom: 1rem;
+  text-align: center;
+  font-weight: bold;
+}
+
+.poll-slider {
+  width: 100%;
+}
+
+.option-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+
+.submit-poll-btn {
+  margin-top: 1rem;
+  padding: 0.6rem 1.2rem;
+  background-color: var(--secondary);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-family: var(--font);
+  cursor: pointer;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.result-chart {
+  max-width: 600px;
+  margin: 0 auto;
+}

--- a/Integrade/widgets/poll/poll.html
+++ b/Integrade/widgets/poll/poll.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Poll</title>
+  <link rel="stylesheet" href="poll.css" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+  <div class="app-container">
+    <header class="app-header">
+      <div class="header-top-row">
+        <img src="../../images/integrade.png" alt="Integrade Logo" class="header-logo" />
+        <p id="room-label-display"></p>
+      </div>
+    </header>
+    <main id="poll-container" class="poll-container">
+      <!-- Poll content will be inserted here -->
+    </main>
+    <button id="submitPoll" class="submit-poll-btn">Submit</button>
+  </div>
+  <script src="poll.js"></script>
+</body>
+</html>

--- a/Integrade/widgets/poll/poll.js
+++ b/Integrade/widgets/poll/poll.js
@@ -1,0 +1,119 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
+  const sessionId = params.get('session');
+  let session = null;
+  if (sessionId) {
+    const raw = sessionStorage.getItem(sessionId);
+    if (raw) {
+      session = JSON.parse(raw);
+    }
+  }
+
+  const roomLabel = document.getElementById('room-label-display');
+  const container = document.getElementById('poll-container');
+  const submitBtn = document.getElementById('submitPoll');
+
+  if (!session) {
+    container.textContent = 'No poll data found.';
+    return;
+  }
+
+  roomLabel.textContent = `Room: ${session.room || 'unknown'}`;
+
+  const questions = Array.isArray(session.questions) ? session.questions : [];
+  const answers = [];
+
+  if (!questions.length) {
+    container.textContent = 'No poll questions found.';
+    return;
+  }
+
+  questions.forEach((q, idx) => {
+    const block = document.createElement('div');
+    block.className = 'poll-question-block';
+
+    const title = document.createElement('h2');
+    title.className = 'poll-question';
+    title.textContent = q.prompt || `Question ${idx + 1}`;
+    block.appendChild(title);
+
+    const slider = document.createElement('input');
+    slider.type = 'range';
+    slider.min = 0;
+    slider.max = Math.max(0, (q.options || []).length - 1);
+    slider.value = 0;
+    slider.step = 1;
+    slider.className = 'poll-slider';
+    block.appendChild(slider);
+
+    const labels = document.createElement('div');
+    labels.className = 'option-labels';
+    (q.options || []).forEach(opt => {
+      const span = document.createElement('span');
+      span.textContent = opt;
+      labels.appendChild(span);
+    });
+    block.appendChild(labels);
+
+    slider.addEventListener('input', () => {
+      answers[idx] = parseInt(slider.value, 10);
+      sessionStorage.setItem(`${sessionId}-answers`, JSON.stringify(answers));
+    });
+
+    container.appendChild(block);
+  });
+
+  submitBtn.addEventListener('click', async () => {
+    try {
+      const resp = await fetch('../../includes/poll_results.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ room: session.room || 'unknown', answers })
+      });
+      const data = await resp.json();
+      if (!data.success) throw new Error(data.error || 'submit failed');
+
+      const resResp = await fetch(`../../includes/poll_results.php?room=${encodeURIComponent(session.room || 'unknown')}`);
+      const resData = await resResp.json();
+      if (resData.success) {
+        showResults(resData.results);
+      } else {
+        alert('Failed to load results');
+      }
+    } catch (e) {
+      console.error(e);
+      alert('Error submitting poll');
+    }
+  });
+
+  function showResults(results) {
+    container.innerHTML = '';
+    questions.forEach((q, idx) => {
+      const canvas = document.createElement('canvas');
+      canvas.className = 'result-chart';
+      container.appendChild(canvas);
+      const counts = [];
+      const labels = [];
+      (q.options || []).forEach((opt, i) => {
+        labels.push(opt);
+        counts.push(results[idx]?.[i] || 0);
+      });
+      new Chart(canvas, {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [{ data: counts, backgroundColor: '#8604e7' }]
+        },
+        options: {
+          plugins: {
+            legend: { display: false },
+            title: { display: true, text: q.prompt }
+          },
+          responsive: true,
+          scales: { y: { beginAtZero: true, precision: 0 } }
+        }
+      });
+    });
+    submitBtn.remove();
+  }
+});

--- a/Integrade/widgets/widgets.css
+++ b/Integrade/widgets/widgets.css
@@ -442,3 +442,55 @@ footer {
   border-radius: 6px;
   font-family: var(--font);
 }
+
+.poll-setup {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-top: 1rem;
+  color: #ddd;
+}
+
+.poll-question-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.poll-question-form .form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.poll-question-form label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.poll-question-form input[type="text"] {
+  padding: 0.6rem;
+  background-color: #111;
+  border: 1px solid var(--primary);
+  color: white;
+  border-radius: 6px;
+  font-family: var(--font);
+}
+
+.add-question-btn,
+.add-option-btn {
+  padding: 0.4rem 0.8rem;
+  background-color: var(--secondary);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-weight: bold;
+  cursor: pointer;
+  font-family: var(--font);
+  width: fit-content;
+}
+
+.add-question-btn {
+  align-self: flex-start;
+}


### PR DESCRIPTION
## Summary
- support creating multiple poll questions with + button
- style poll setup inputs to match jamboard design
- render poll questions on poll page with range slider and save answers
- submit poll answers to backend and display bar charts of results

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68400116c6f88326bf3a2d37f8384d1b